### PR TITLE
Fix/engine method calls inside behaviours

### DIFF
--- a/ScalaGameEngine/src/main/scala/sge/core/Engine.scala
+++ b/ScalaGameEngine/src/main/scala/sge/core/Engine.scala
@@ -109,10 +109,11 @@ object Engine:
         gameObjectsToDisable = gameObjectsToDisable + gameObject
 
     private def disableObjectsToBeDisabled(): Unit =
-      gameObjectsToDisable.foreach: o =>
+      val disabled = Set.from(gameObjectsToDisable)
+      gameObjectsToDisable = Set.empty
+      disabled.foreach: o =>
         o.enabled = false
         o.onDisabled(this)
-      gameObjectsToDisable = Set.empty
 
     override def create(gameObject: Behaviour): Unit =
       if gameObjects.exists(_ eq gameObject) || gameObjectsToAdd(gameObject)

--- a/ScalaGameEngine/src/main/scala/sge/core/Engine.scala
+++ b/ScalaGameEngine/src/main/scala/sge/core/Engine.scala
@@ -148,9 +148,10 @@ object Engine:
 
     private def applyCreate(): Unit =
       gameObjects = gameObjects ++ gameObjectsToAdd
-      gameObjectsToAdd.foreach(_.onInit(this))
-      gameObjectsToAdd.filter(_.enabled).foreach(_.onStart(this))
+      val created = Set.from(gameObjectsToAdd)
       gameObjectsToAdd = Set.empty
+      created.foreach(_.onInit(this))
+      created.filter(_.enabled).foreach(_.onStart(this))
 
     private def applyDestroy(): Unit =
       gameObjects = gameObjects.filterNot(gameObjectsToRemove.contains)

--- a/ScalaGameEngine/src/main/scala/sge/core/Engine.scala
+++ b/ScalaGameEngine/src/main/scala/sge/core/Engine.scala
@@ -155,8 +155,9 @@ object Engine:
 
     private def applyDestroy(): Unit =
       gameObjects = gameObjects.filterNot(gameObjectsToRemove.contains)
-      gameObjectsToRemove.foreach(_.onDeinit(this))
+      val destroyed = Set.from(gameObjectsToRemove)
       gameObjectsToRemove = Set.empty
+      destroyed.foreach(_.onDeinit(this))
 
     private var shouldStop = false
     private var alreadyStarted = false

--- a/ScalaGameEngine/src/main/scala/sge/core/Engine.scala
+++ b/ScalaGameEngine/src/main/scala/sge/core/Engine.scala
@@ -96,12 +96,13 @@ object Engine:
         gameObjectsToEnable = gameObjectsToEnable + gameObject
 
     private def enableObjectsToBeEnabled(): Unit =
-      gameObjectsToEnable.foreach: o =>
+      val enabled = Set.from(gameObjectsToEnable)
+      gameObjectsToEnable = Set.empty
+      enabled.foreach: o =>
         o.enabled = true
         o.onEnabled(this)
-      gameObjectsToEnable.foreach: o =>
+      enabled.foreach: o =>
         o.onStart(this)
-      gameObjectsToEnable = Set.empty
 
     override def disable(gameObject: Behaviour): Unit =
       if gameObject.enabled then

--- a/ScalaGameEngine/src/test/scala/sge/core/EngineObjectCreationTests.scala
+++ b/ScalaGameEngine/src/test/scala/sge/core/EngineObjectCreationTests.scala
@@ -173,3 +173,18 @@ class EngineObjectCreationTests extends AnyFlatSpec with BeforeAndAfterEach:
           LateUpdate,
           Deinit
         )
+
+  it should "work when called inside onDeinit in a destroyed object" in :
+    var destroyed = false
+    val objCreator = new Behaviour:
+      override def onDeinit: Engine => Unit = e =>
+        destroyed = true
+        e.destroy(obj1)
+    val sceneWithCreator: Scene = () => Seq(objCreator, obj1)
+
+    test(engine) on sceneWithCreator runningFor 3 frames so that :
+      _.onUpdate:
+        if !destroyed then
+          engine.destroy(objCreator)
+      .onDeinit:
+        engine.find[GameObjectMock]() shouldBe empty

--- a/ScalaGameEngine/src/test/scala/sge/core/EngineObjectCreationTests.scala
+++ b/ScalaGameEngine/src/test/scala/sge/core/EngineObjectCreationTests.scala
@@ -86,6 +86,21 @@ class EngineObjectCreationTests extends AnyFlatSpec with BeforeAndAfterEach:
     objTester.happenedEvents should contain theSameElementsInOrderAs
       Seq(Init, Start, EarlyUpdate, Update, LateUpdate, Deinit)
 
+  it should "work when called inside onInit in a created object" in:
+    var created = false
+    val objCreator = new Behaviour:
+      override def onInit: Engine => Unit = e =>
+        created = true
+        e.create(obj1)
+
+    test(engine) runningFor 3 frames so that:
+      _.onUpdate:
+        if !created then
+          engine.create(objCreator)
+      .onDeinit:
+        engine.find[GameObjectMock]() should contain (obj1)
+
+
   "destroy" should "remove a game object from the scene" in:
     test(engine) on scene soThat:
       _.onStart:

--- a/ScalaGameEngine/src/test/scala/sge/core/EngineObjectCreationTests.scala
+++ b/ScalaGameEngine/src/test/scala/sge/core/EngineObjectCreationTests.scala
@@ -100,6 +100,20 @@ class EngineObjectCreationTests extends AnyFlatSpec with BeforeAndAfterEach:
       .onDeinit:
         engine.find[GameObjectMock]() should contain (obj1)
 
+  it should "work when called inside onStart in a created object" in:
+    var created = false
+    val objCreator = new Behaviour:
+      override def onStart: Engine => Unit = e =>
+        created = true
+        e.create(obj1)
+
+    test(engine) runningFor 3 frames so that :
+      _.onUpdate:
+        if !created then
+          engine.create(objCreator)
+      .onDeinit:
+        engine.find[GameObjectMock]() should contain(obj1)
+
 
   "destroy" should "remove a game object from the scene" in:
     test(engine) on scene soThat:

--- a/ScalaGameEngine/src/test/scala/sge/core/EngineObjectsEnableDisableTests.scala
+++ b/ScalaGameEngine/src/test/scala/sge/core/EngineObjectsEnableDisableTests.scala
@@ -108,6 +108,25 @@ class EngineObjectsEnableDisableTests
         val obj = engine.find[TestObj](disabledId).get
         obj.happenedEvents should contain(Enable)
 
+  it should "work when called inside onStart in a just enabled object" in :
+    var alreadyEnabled = false
+    val objEnabler = new TestObj(false, disabledId):
+      override def onStart: Engine => Unit = e =>
+        alreadyEnabled = true
+        val obj = engine.find[TestObj](disabledId).get
+        e.enable(obj)
+
+    val testSceneWithEnabler: Scene = testScene.joined(() => Seq(objEnabler))
+
+    test(engine) on testSceneWithEnabler runningFor 3 frames so that :
+      _.onUpdate:
+        if !alreadyEnabled then
+          val obj = engine.find[TestObj](disabledId).get
+          engine.enable(objEnabler)
+      .onDeinit:
+        val obj = engine.find[TestObj](disabledId).get
+        obj.happenedEvents should contain(Enable)
+
   "Engine" should "allow to dinamically disable objects" in:
     test(engine) on testScene soThat:
       _.onUpdate:

--- a/ScalaGameEngine/src/test/scala/sge/core/EngineObjectsEnableDisableTests.scala
+++ b/ScalaGameEngine/src/test/scala/sge/core/EngineObjectsEnableDisableTests.scala
@@ -161,6 +161,25 @@ class EngineObjectsEnableDisableTests
         val obj = engine.find[TestObj](enabledId).get
         obj.happenedEvents.count(_ == Disable) shouldBe 1
 
+  it should "work when called inside onDisabled in a just disabled object" in :
+    var alreadyDisabled = false
+    val objDisabler = new TestObj(true, enabledId):
+      override def onDisabled: Engine => Unit = e =>
+        alreadyDisabled = true
+        val obj = engine.find[TestObj](enabledId).get
+        e.disable(obj)
+
+    val testSceneWithEnabler: Scene = testScene.joined(() => Seq(objDisabler))
+
+    test(engine) on testSceneWithEnabler runningFor 3 frames so that :
+      _.onUpdate:
+        if !alreadyDisabled then
+          val obj = engine.find[TestObj](enabledId).get
+          engine.disable(objDisabler)
+      .onDeinit:
+        val obj = engine.find[TestObj](enabledId).get
+        obj.happenedEvents should contain(Disable)
+
   "Engine" should "allow to disable and enable the same object multiple times" in:
     var frame = 1
     test(engine) on testScene runningFor 3 frames so that:


### PR DESCRIPTION
Ho fixato i bug che c'erano nell'engine, ora le chiamate create(), destroy(), enable() e disable() si possono fare anche dentro oggetti appena creati/eliminati/abilitati/disabilitati.